### PR TITLE
feat: add cluster argocd as a target for argocd rhdh plugin

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,9 @@
+# Can be used to run the role locally via "ansible-playbook site.yml"
+---
+- hosts: localhost
+  connection: local
+  gather_facts: true
+  vars_files:
+    - defaults/main.yml
+  tasks:
+    - include_tasks: tasks/main.yml

--- a/site.yml
+++ b/site.yml
@@ -1,9 +1,0 @@
-# Can be used to run the role locally via "ansible-playbook site.yml"
----
-- hosts: localhost
-  connection: local
-  gather_facts: true
-  vars_files:
-    - defaults/main.yml
-  tasks:
-    - include_tasks: tasks/main.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -201,3 +201,101 @@
       data:
         .npmrc: "{{ '@redhat:registry=https://npm.registry.redhat.com' | b64encode }}"
 
+- name: Get cluster ArgoCD route from openshift-gitops namespace
+  shell: >
+    oc -n openshift-gitops get route openshift-gitops-server -o jsonpath='{.spec.host}'
+  register: cluster_argo_route
+  changed_when: false
+
+- name: Set cluster ArgoCD URL fact
+  set_fact:
+    cluster_argo_url: "https://{{ cluster_argo_route.stdout }}"
+
+- name: Retrieve cluster ArgoCD credentials from openshift-gitops namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: openshift-gitops-cluster
+    namespace: "openshift-gitops"
+  register: r_cluster_argo_credentials
+  retries: 120
+  delay: 10
+  until:
+    - r_cluster_argo_credentials is defined
+    - r_cluster_argo_credentials.resources is defined
+    - r_cluster_argo_credentials.resources | length > 0
+
+- name: Set cluster ArgoCD admin password fact
+  set_fact:
+    cluster_argo_password: "{{ r_cluster_argo_credentials.resources[0].data['admin.password'] | b64decode }}"
+
+- name: Get current tssc-developer-hub-env Secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: tssc-developer-hub-env
+    namespace: tssc-dh
+  register: current_dh_env_secret
+
+- name: Patch tssc-developer-hub-env Secret with cluster ArgoCD environment variables
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: tssc-developer-hub-env
+        namespace: tssc-dh
+      type: Opaque
+      data: >-
+        {{
+          current_dh_env_secret.resources[0].data | combine({
+            'CLUSTER_ARGOCD_URL': cluster_argo_url | b64encode,
+            'CLUSTER_ARGOCD_PASSWORD': cluster_argo_password | b64encode
+          })
+        }}
+
+- name: Get current tssc-developer-hub-app-config ConfigMap
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: tssc-developer-hub-app-config
+    namespace: tssc-dh
+  register: current_app_config
+
+- name: Parse current app-config.yaml content
+  set_fact:
+    app_config_yaml: "{{ current_app_config.resources[0].data['app-config.tssc.yaml'] | from_yaml }}"
+
+- name: Add cluster ArgoCD instance to argocd.appLocatorMethods[0].instances
+  set_fact:
+    updated_app_config: >-
+      {{
+        app_config_yaml | combine({
+          'argocd': app_config_yaml.argocd | combine({
+            'appLocatorMethods': [
+              app_config_yaml.argocd.appLocatorMethods[0] | combine({
+                'instances': app_config_yaml.argocd.appLocatorMethods[0].instances + [{
+                  'name': 'cluster-argocd',
+                  'url': '${CLUSTER_ARGOCD_URL}',
+                  'username': 'admin',
+                  'password': '${CLUSTER_ARGOCD_PASSWORD}'
+                }]
+              })
+            ] + (app_config_yaml.argocd.appLocatorMethods[1:] | default([]))
+          })
+        }, recursive=True)
+      }}
+
+- name: Patch tssc-developer-hub-app-config ConfigMap with new ArgoCD instance
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: tssc-developer-hub-app-config
+        namespace: tssc-dh
+      data:
+        app-config.tssc.yaml: "{{ updated_app_config | to_nice_yaml }}"
+


### PR DESCRIPTION
This patches the Developer Hub config to enable integration with not just tssc-gitops, but also openshift-gitops.